### PR TITLE
Adding mkl library path to the LD_LIBRARY_PATH

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -58,7 +58,7 @@ jobs:
       BASE_DIR: /opt/intel/oneapi/compiler/latest/linux
       INSTALL_PATH: /opt/intel/oneapi/compiler/latest/linux/bin/intel64
       MKLROOT: /opt/intel/oneapi/mkl/latest
-      LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/ipp/lib/intel64
+      LD_LIBRARY_PATH: /opt/intel/oneapi/mkl/latest/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/ipp/lib/intel64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -58,7 +58,7 @@ jobs:
       BASE_DIR: /opt/intel/oneapi/compiler/latest/linux
       INSTALL_PATH: /opt/intel/oneapi/compiler/latest/linux/bin/intel64
       MKLROOT: /opt/intel/oneapi/mkl/latest
-      LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/ipp/lib/intel64
+      LD_LIBRARY_PATH: /opt/intel/oneapi/mkl/latest/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/ipp/lib/intel64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
@@ -84,10 +84,19 @@ jobs:
       - name: Setup Intel oneAPI environment
         run: |
           source /opt/intel/oneapi/setvars.sh
-      - name: Debugging
-        run: |
+          source /opt/intel/oneapi/mkl/latest/env/vars.sh
           echo "Checking LD_LIBRARY_PATH"
           echo $LD_LIBRARY_PATH
+      - name: Debugging
+        run: |
+          echo 'Running export | grep "intel" -i'
+          export | grep "intel" -i
+          echo "Checking LD_LIBRARY_PATH"
+          echo $LD_LIBRARY_PATH
+          echo "List /opt/intel/oneapi/compiler/latest/linux/compiler/lib/"
+          ls -lR /opt/intel/oneapi/compiler/latest/linux/compiler/lib/
+          echo "List MKLROOT"
+          ls -lR $MKLROOT
       - name: Compile
         run: |
           make -f Makefile.ifort FC=${{ env.INSTALL_PATH }}/ifort \

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -85,18 +85,6 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           source /opt/intel/oneapi/mkl/latest/env/vars.sh
-          echo "Checking LD_LIBRARY_PATH"
-          echo $LD_LIBRARY_PATH
-      - name: Debugging
-        run: |
-          echo 'Running export | grep "intel" -i'
-          export | grep "intel" -i
-          echo "Checking LD_LIBRARY_PATH"
-          echo $LD_LIBRARY_PATH
-          echo "List /opt/intel/oneapi/compiler/latest/linux/compiler/lib/"
-          ls -lR /opt/intel/oneapi/compiler/latest/linux/compiler/lib/
-          echo "List MKLROOT"
-          ls -lR $MKLROOT
       - name: Compile
         run: |
           make -f Makefile.ifort FC=${{ env.INSTALL_PATH }}/ifort \

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,7 +56,7 @@ jobs:
       BASE_DIR: /opt/intel/oneapi/compiler/latest/linux
       INSTALL_PATH: /opt/intel/oneapi/compiler/latest/linux/bin/intel64
       MKLROOT: /opt/intel/oneapi/mkl/latest
-      LD_LIBRARY_PATH: /opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/ipp/lib/intel64
+      LD_LIBRARY_PATH: /opt/intel/oneapi/mkl/latest/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64:/opt/intel/oneapi/compiler/latest/linux/ipp/lib/intel64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Fixed:
- Workflow run due to missing `libmkl_intel_lp64.so.2` shared object file

Added:
- MKL library path to the `LD_LIBRARY_PATH` environment variable on all three workflow files.
