### PR TITLE
Some modifications to generate the MChD A terms correctly

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -8,10 +8,15 @@
 
 
 ### Fortran compiler
-FC     = gfortran
-FC90   = gfortran
+#FC     = gfortran
+#FC90   = gfortran
 
-LINKER = gfortran
+#LINKER = gfortran
+
+FC     = gfortran-mp-11
+FC90   = gfortran-mp-11
+
+LINKER = gfortran-mp-11
 
 ### Disable/Enable OpenMP support
 OMP = 

--- a/diagonalize-magdip-all.f90
+++ b/diagonalize-magdip-all.f90
@@ -1,10 +1,10 @@
 
 subroutine diagonalize_magdip_all (idir)
 
-  ! -------------------------------------------------
+  ! -------------------------------------------------------
   ! diagonalize the Zeeman Hamiltonian component idir
-  ! within the degenerate GS
-  ! -------------------------------------------------
+  ! within all set of degenerate states one after the other
+  ! -------------------------------------------------------
   
   use definitions
   
@@ -36,11 +36,16 @@ subroutine diagonalize_magdip_all (idir)
 
     if (ndeg.gt.1) then ! if not, there is nothing to do
 
-      write(out,*) 'I am working'
+      if (dbg>0) then
+        if (dbg>1) then
+          write(out,'(1x,25(''.'')/,/1x,a,1x,i5/)') 'For level', n
+        end if
+        write(out,'(/1x,a/)') 'diagonalize-magdip-all is working :'
+      end if ! dbg
 
       if ((nfin - nint + 1).ne.ndeg) then
         write(out,*) 'n, nint, nfin, ndeg', n, nint, nfin, ndeg
-        stop 'error in diAGONALIZE magdip'
+        stop 'error in diagonalize magdip'
       end if
 
       ! the next call uses the complex lapack routine zheevd.
@@ -72,11 +77,17 @@ subroutine diagonalize_magdip_all (idir)
         deallocate (tmpmat2)
       end do
 
-      call print_rec_matrix(out, ndeg, real(magdip(nint:nfin,nint:nfin,idir)),&
-        & 'Transformed Zeeman Hamiltonian REAL part')
+      if (dbg>0) then
 
-      call print_rec_matrix(out, ndeg, aimag(magdip(nint:nfin,nint:nfin,idir)),&
-        & 'Transformed Zeeman Hamiltonian IMAG part')
+        write (out,'(/1x,a/)') 'Thus'
+
+        call print_rec_matrix(out, ndeg, real(magdip(nint:nfin,nint:nfin,idir)),&
+          & 'Transformed Zeeman Hamiltonian REAL part')
+
+        call print_rec_matrix(out, ndeg, aimag(magdip(nint:nfin,nint:nfin,idir)),&
+          & 'Transformed Zeeman Hamiltonian IMAG part')
+
+      end if ! dbg
 
       ! -------------------------------------------------------
       ! transform the dipole and quad matrix elements between the GS
@@ -114,16 +125,5 @@ subroutine diagonalize_magdip_all (idir)
     end if ! end of the procdure for one degeneracy
   
   end do ! loop over all degenerated states
-
-
-!!$      if (dbg>1) then
-!!$      allocate (tmpmat1(nstates, nstates))      
-!!$      do jdir = 1,3
-!!$        tmpmat1 = transpose(conjg(eldip(:,:,jdir)))
-!!$        tmpmat1 = tmpmat1 - eldip(:,:,jdir)        
-!!$        write (out,*) jdir, pack(tmpmat1(:,:), abs(tmpmat1(:,:))>tiny)        
-!!$      end do ! jdir      
-!!$      deallocate (tmpmat1)      
-!!$    end if ! dbg
   
 end subroutine diagonalize_magdip_all

--- a/diagonalize-matrix.f90
+++ b/diagonalize-matrix.f90
@@ -65,7 +65,7 @@ subroutine diagonalize_matrix (n, a)
 
   deallocate(iwork,work,rwork)
 
-  if (dbg>1) write(out,*) a(:,:)
+  if (dbg>2) write(out,*) a(:,:)
 
   ! in order to compare with Mathematica et al., 
   ! let's fix the phases of the eigenvectors such that

--- a/mchd-c-molcas.f90
+++ b/mchd-c-molcas.f90
@@ -470,8 +470,8 @@ program mchd_c_molcas
   
   do idir = 0,3
     close (iu_out(idir))
-    write (out,'(1x,a,1x,i7,1x,a,1x,a)') 'wrote C-term data for', &
-      nstates-degen-skip,'transitions to file',trim(outfile(idir))  
+    write (out,'(1x,a,1x,i7,1x,a,1x,a)') 'wrote C-terms data for', &
+      nlevels - skip - 1,'transitions to file',trim(outfile(idir))  
   end do
 
   call print_constants


### PR DESCRIPTION
The inclusion of the electric quadrupoles to calculate the MChD A(A') term has been corrected.

Some debugging prints have been set to verify the correct diagonalisation of the Zeeman Hamiltonian within each set of degenerate states in succession for the calculation of MChD A terms.

Bonus: Correction of the counting of calculated transitions for both MChD A and C terms.
/!\ Makefile.gnu required different settings for me. It may not be useful to include this personal fix. If in doubt, I put it in the pull request.